### PR TITLE
Update price-tick-db.js

### DIFF
--- a/project/backend/price-tick-db.js
+++ b/project/backend/price-tick-db.js
@@ -20,6 +20,16 @@ export async function connectMongo() {
 export async function savePriceTick(price, timestamp) {
   const col = await connectMongo();
   await col.insertOne({ price, timestamp });
+  const count = await col.countDocuments();
+  if (count > 500) {
+    const toDelete = await col
+      .find({})
+      .sort({ timestamp: 1 })
+      .limit(count - 500)
+      .toArray();
+    const ids = toDelete.map((doc) => doc._id);
+    await col.deleteMany({ _id: { $in: ids } });
+  }
 }
 
 export async function getRecentPriceTicks(limit = 100) {


### PR DESCRIPTION
Fixed allowing infinite DB items from going in, and limited the items to a max of 500. Any additional items will replace oldest previous